### PR TITLE
セキュリティアラートの回避

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.1)
     netrc (0.11.0)
     nio4r (2.5.2)
     nokogiri (1.10.9)


### PR DESCRIPTION
# What
下記アラートが発生したので、それを避けるための対応

> Dependabot cannot update to the required version

# Why
脆弱性の回避のため