### PR TITLE
fix: postgreSQLのgemをアンインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'faker', "~> 2.8"
   gem 'capybara'
-  gem 'pg'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,6 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
-    pg (1.2.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -340,7 +339,6 @@ DEPENDENCIES
   meta-tags
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
-  pg
   pry-rails
   puma (~> 3.12)
   rails (~> 5.0.7, >= 5.0.7.2)


### PR DESCRIPTION
# What
Gemfileから`pg`（postgreSQLのgem）をアンインストール

# Why
AWSではMySQLを使用するため