### PR TITLE
独自ドメインの取得、HTTPS化

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
# What
独自ドメインの取得、HTTPS化
・ドメインはお名前.comで取得（furima-68d.work）
・Route53にドメイン委任して名前解決
・ACMでSSL証明書を取得
・ロードバランサーに設定
・nginxの設定をドメインでアクセスできるように変更

# Why
・HTTPS化されていないとGoogleのアラートが表示される可能性がある
・Elastic IPだとアクセスしにくい
など、アプリの根幹に関わるため