### PR TITLE
店舗の検索結果を並び替えて表示する機能の実装

### DIFF
--- a/app/assets/javascripts/shop_search.js
+++ b/app/assets/javascripts/shop_search.js
@@ -7,11 +7,11 @@ $(function() {
     // value属性の値により、ページ遷移先の分岐
 
     switch (sort_order) {
-      case 'woms-desc': html = "&sort=woms_count_desc"; break;
       case 'rate-desc': html = "&sort=rate_desc"; break;
-      case 'rate-asc': html = "&sort=rate_asc"; break;
-      case 'created_at-desc': html = "&sort=created_at+desc"; break;
+      case 'woms-desc': html = "&sort=woms_count_desc"; break;
+      case 'clips-desc': html = "&sort=clips_count_desc"; break;
       case 'created_at-asc': html = "&sort=created_at+asc"; break;
+      case 'created_at-desc': html = "&sort=created_at+desc"; break;
       default: html = "&sort=created_at+desc"; 
     }
     // 現在の表示ページ
@@ -38,11 +38,11 @@ $(function() {
       const selected_option = location['href'].match(/&sort=*.+/)[0].replace('&sort=', '');
 
       switch (selected_option) {
-        case "woms_count_desc": var sort = 1; break;
-        case "rate_desc": var sort = 2; break;
-        case "rate_asc": var sort = 3; break;
-        case "created_at+desc": var sort = 4; break;
-        case "created_at+asc": var sort = 5; break;
+        case "rate_desc": var sort = 1; break;
+        case "woms_count_desc": var sort = 2; break;
+        case "clips_count_desc": var sort = 3; break;
+        case "created_at+asc": var sort = 4; break;
+        case "created_at+desc": var sort = 5; break;
         default: var sort = 0
       }
       const add_selected = $('select[name=sort_order]').children()[sort]

--- a/app/assets/javascripts/shop_search.js
+++ b/app/assets/javascripts/shop_search.js
@@ -1,0 +1,52 @@
+// 並び替えの挙動
+$(function() {
+  // プルダウンメニューを選択することでイベントが発生
+  $('select[name=sort_order]').change(function() {
+    // 選択したoptionタグのvalue属性を取得する
+    const sort_order = $(this).val();
+    // value属性の値により、ページ遷移先の分岐
+
+    switch (sort_order) {
+      case 'woms-desc': html = "&sort=woms_count_desc"; break;
+      case 'rate-desc': html = "&sort=rate_desc"; break;
+      case 'rate-asc': html = "&sort=rate_asc"; break;
+      case 'created_at-desc': html = "&sort=created_at+desc"; break;
+      case 'created_at-asc': html = "&sort=created_at+asc"; break;
+      default: html = "&sort=created_at+desc"; 
+    }
+    // 現在の表示ページ
+    let current_html = window.location.href;
+    if (location['href'].match(/search=*.+/) == null) {
+      html = "/search?q%5Barea_name_cont%5D=" + html
+    }
+    // ソート機能の重複防止 
+    if (location['href'].match(/&sort=*.+/) != null) {
+      var remove = location['href'].match(/&sort=*.+/)[0]
+      current_html = current_html.replace(remove, '')
+    };
+    // ページ遷移
+    window.location.href = current_html + html
+  });
+  // ページ遷移後の挙動
+  $(function () {
+    if (location['href'].match(/&sort=*.+/) != null) {
+      // option[selected: 'selected']を削除
+      if ($('select option[selected=selected]')) {
+        $('select option:first').prop('selected', false);
+      }
+
+      const selected_option = location['href'].match(/&sort=*.+/)[0].replace('&sort=', '');
+
+      switch (selected_option) {
+        case "woms_count_desc": var sort = 1; break;
+        case "rate_desc": var sort = 2; break;
+        case "rate_asc": var sort = 3; break;
+        case "created_at+desc": var sort = 4; break;
+        case "created_at+asc": var sort = 5; break;
+        default: var sort = 0
+      }
+      const add_selected = $('select[name=sort_order]').children()[sort]
+      $(add_selected).attr('selected', true)
+    }
+  });
+});

--- a/app/assets/stylesheets/pages/_shops.scss
+++ b/app/assets/stylesheets/pages/_shops.scss
@@ -137,7 +137,7 @@
             font-size: 20px;
             font-weight: bold;
           }
-          .shop-wom-count {
+          .shop-count {
             margin-left: 8px;
             color: $color-no-action;
             text-decoration: underline;

--- a/app/assets/stylesheets/pages/_shops.scss
+++ b/app/assets/stylesheets/pages/_shops.scss
@@ -3,6 +3,28 @@
   margin: 16px 0;
   font-size: $fSize-content;
 }
+// 並び替え
+.searched_heading-box {
+  @include up-down-center;
+  justify-content: space-between;
+  &__result {
+    &__keyword {
+      font-size: $fSize-h2;
+    }
+  }
+  &__sort {
+    & select {
+      height: 48px;
+      padding: 4px;
+      font-size: $fSize-content;
+      &:focus {
+        border: $border-style-hover;
+        border-radius: 3px;
+        outline: 0;
+      }
+    }
+  }
+}
 // Shop一覧
 .shop-list {
   .shop {

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -7,6 +7,10 @@ class ShopsController < ApplicationController
 
   def index
     @shops = Shop.shop_includes.paginate(page: params[:page], per_page: 5)
+    @result = @shops.count
+    @keyword = "全ての古着屋"
+    sort = params[:sort] || "created_at DESC"
+    shop_sort(sort)
     if params[:user_id].presence
       @user = User.find(params[:user_id])
       render "users/shops"

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -60,19 +60,27 @@ class ShopsController < ApplicationController
     area_keyword = params.require(:q)[:area_name_cont]
     searched_word = params.require(:q)[:name_or_outline_or_brands_name_or_genres_name_cont]
     @keyword = view_context.search_result_word(genre, brand, area_keyword, searched_word, @rate_range)
-    #検索ワードがなければ、店舗一覧にリダイレクト
-    redirect_to shops_path if @keyword == nil && @rate_range == nil
+    # 検索ワードがなければ、店舗一覧にリダイレクト
 
-    sort = params[:sort] || "created_at DESC"
     @q = Shop.shop_includes.search(search_params)
     if @rate_range.present?
       # @shops = @q.result(distinct: true).where('rating_average >= ?', rate_range.min).order(sort).paginate(page: params[:page], per_page: 5)
-      @shops = @q.result(distinct: true).select('shops.*', 'sum(woms.rate) AS rate_sum').select('shops.*', 'count(woms.id) AS rate_count').left_joins(:woms).group('shops.id').having('rate_sum/rate_count >=?', @rate_range.min).order(sort).paginate(page: params[:page], per_page: 5)
+      @shops = @q.result(distinct: true)
+        .select('shops.*', 'sum(woms.rate) AS rate_sum')
+        .select('shops.*', 'count(woms.id) AS rate_count')
+        .left_joins(:woms)
+        .group('shops.id')
+        .having('rate_sum/rate_count >=?', @rate_range.min)
       @result = @shops.length
     else
-      @shops = @q.result(distinct: true).order(sort).paginate(page: params[:page], per_page: 5)
+      @shops = @q.result(distinct: true)
       @result = @shops.count
     end
+
+    # ソートを判定
+    sort = params[:sort] || "created_at DESC"
+    shop_sort(sort)
+    redirect_to shops_path(sort: sort) if @keyword == nil && @rate_range == nil
   end
 
   private
@@ -114,5 +122,31 @@ class ShopsController < ApplicationController
 
   def move_to_root    
     redirect_to root_path unless user_signed_in? && current_user.admin?
+  end
+
+  def shop_sort(sort)
+    # ソートを判定
+    case sort
+    when "woms_count_desc" then
+      @shops = @shops.select('shops.*', 'count(woms.id) AS woms')
+        .left_joins(:woms)
+        .group('shops.id')
+        .order('woms DESC')
+        .paginate(page: params[:page], per_page: 5)
+    when "rate_desc" then
+      @shops = @shops
+        .joins("left join woms on shops.id=woms.shop_id")
+        .group("shops.id")
+        .order("sum(woms.rate)/count(woms.id) desc")
+        .paginate(page: params[:page], per_page: 5)
+    when "rate_asc" then
+      @shops = @shops
+        .joins("left join woms on shops.id=woms.shop_id")
+        .group("shops.id")
+        .order("sum(woms.rate)/count(woms.id) asc")
+        .paginate(page: params[:page], per_page: 5)
+    else
+      @shops = @shops.order(sort).paginate(page: params[:page], per_page: 5)
+    end
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -131,23 +131,23 @@ class ShopsController < ApplicationController
   def shop_sort(sort)
     # ソートを判定
     case sort
-    when "woms_count_desc" then
-      @shops = @shops.select('shops.*', 'count(woms.id) AS woms')
-        .left_joins(:woms)
-        .group('shops.id')
-        .order('woms DESC')
-        .paginate(page: params[:page], per_page: 5)
     when "rate_desc" then
       @shops = @shops
         .joins("left join woms on shops.id=woms.shop_id")
         .group("shops.id")
         .order("sum(woms.rate)/count(woms.id) desc")
         .paginate(page: params[:page], per_page: 5)
-    when "rate_asc" then
-      @shops = @shops
-        .joins("left join woms on shops.id=woms.shop_id")
-        .group("shops.id")
-        .order("sum(woms.rate)/count(woms.id) asc")
+    when "woms_count_desc" then
+      @shops = @shops.select('shops.*', 'count(woms.id) AS woms')
+        .left_joins(:woms)
+        .group('shops.id')
+        .order('woms DESC')
+        .paginate(page: params[:page], per_page: 5)
+    when "clips_count_desc" then
+      @shops = @shops.select('shops.*', 'count(clips.id) AS clips')
+        .left_joins(:clips)
+        .group('shops.id')
+        .order('clips DESC')
         .paginate(page: params[:page], per_page: 5)
     else
       @shops = @shops.order(sort).paginate(page: params[:page], per_page: 5)

--- a/app/views/shops/_searched_heading.html.haml
+++ b/app/views/shops/_searched_heading.html.haml
@@ -1,0 +1,18 @@
+.searched_heading-box
+  .searched_heading-box__result
+    %span.searched_heading-box__result__keyword= @keyword
+    %span.searched_heading-box__result__count= "#{@result}件"
+  .searched_heading-box__sort
+    %select{name: :sort_order, class: 'sort-order .searched_heading-box__sort__select'}
+      %option{value: "location.pathname", name: "location.pathname"}
+        並び替え
+      %option{value: "woms-desc"}
+        口コミの多い順
+      %option{value: "rate-desc"}
+        評価の高い順
+      %option{value: "rate-asc"}
+        評価の低い順
+      %option{value: "created_at-desc"}
+        登録の新しい順
+      %option{value: "created_at-asc"}
+        登録の古い順

--- a/app/views/shops/_searched_heading.html.haml
+++ b/app/views/shops/_searched_heading.html.haml
@@ -6,13 +6,13 @@
     %select{name: :sort_order, class: 'sort-order .searched_heading-box__sort__select'}
       %option{value: "location.pathname", name: "location.pathname"}
         並び替え
-      %option{value: "woms-desc"}
-        口コミの多い順
       %option{value: "rate-desc"}
         評価の高い順
-      %option{value: "rate-asc"}
-        評価の低い順
-      %option{value: "created_at-desc"}
-        登録の新しい順
+      %option{value: "woms-desc"}
+        口コミの多い順
+      %option{value: "clips-desc"}
+        保存済みの多い順
       %option{value: "created_at-asc"}
-        登録の古い順
+        登録順
+      %option{value: "created_at-desc"}
+        新着順

--- a/app/views/shops/_shop.html.haml
+++ b/app/views/shops/_shop.html.haml
@@ -47,9 +47,12 @@
                     readOnly: true,
                     score: "#{shop.woms.average(:rate).to_f.round(2)}",
                   });
-                .shop-wom-count
+                .shop-count
                   %i.fas.fa-comment-dots<>
                   = "#{shop.woms.where.not(rate: nil).count}件"
+                .shop-count
+                  %i.fas.fa-bookmark.fa-lg<>
+                  = "#{shop.clips.count}件"
               .bottom-info-right__top-wom
                 .wom-info
                   .wom-info__title

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -1,5 +1,6 @@
 - breadcrumb :shops
 = render "layouts/breadcrumbs"
+= render "shops/searched_heading"
 .shop-paginate
   = will_paginate @shops, renderer: WillPaginate::ActionView::LinkRenderer
 = render 'shop', shops: @shops

--- a/app/views/shops/search.html.haml
+++ b/app/views/shops/search.html.haml
@@ -1,6 +1,6 @@
 - breadcrumb :search_shops, @keyword
 = render "layouts/breadcrumbs"
-= "#{@keyword} ：#{@result}件"
+= render "shops/searched_heading"
 .shop-paginate
   = will_paginate @shops, renderer: WillPaginate::ActionView::LinkRenderer
 = render "shops/shop", shops: @shops

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -4,7 +4,7 @@ end
 
 # shop#index
 crumb :shops do
-  link "Shop一覧", shops_path
+  link "全ての古着屋", shops_path
   parent :root
 end
 


### PR DESCRIPTION
# What
店舗の一覧表示画面で、下記の方法を選択し、それに応じて表示を並び替える機能を実装
- 口コミの評価順
- 口コミの数順
- お気に入りの数順
- 新着（新規登録）順

# Why
評価が高い店舗、口コミが多い（来店した人数が多い・評価の質を信頼できる）店舗、お気に入りの数が多い店舗を探しやすくすることで、下記2つの効果を得られると見込めるため

1. ユーザ側：評価の高いお店を探しやすくなり、サイトへの依存度が高まる
2. 店舗側：評価を上げる・お気に入りを増やすために、顧客満足度を上げようと努める
上記2つを相乗効果的に相関させることで、本アプリの目的の達成に近づく、と考える