### PR TITLE
CSVによる商品の一括登録機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,4 @@ gem 'aws-sdk-s3'
 gem 'bootsnap', require: false
 gem 'bootstrap-sass'
 gem 'data-confirm-modal'
+gem 'roo'

--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,4 @@ gem 'bootsnap', require: false
 gem 'bootstrap-sass'
 gem 'data-confirm-modal'
 gem 'roo'
+gem 'will_paginate-bootstrap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,9 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
+    roo (2.8.3)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -338,6 +341,7 @@ GEM
       ffi (~> 1.9)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
+    rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -456,6 +460,7 @@ DEPENDENCIES
   rails-i18n
   ransack
   rename
+  roo
   rspec-rails
   sass-rails (~> 5.0)
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,6 +411,8 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (3.3.0)
+    will_paginate-bootstrap (1.0.2)
+      will_paginate (>= 3.0.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -470,6 +472,7 @@ DEPENDENCIES
   unicorn (= 5.4.1)
   web-console
   will_paginate
+  will_paginate-bootstrap
 
 BUNDLED WITH
    2.1.4

--- a/app/assets/stylesheets/pages/_items.scss
+++ b/app/assets/stylesheets/pages/_items.scss
@@ -41,13 +41,14 @@
     }
     &__list {
       display: flex;
+      flex-wrap: wrap;
       & a {
         color: $color_default;
         text-decoration: none;
       }
       &__item {
         max-width: 180px;
-        margin: 0 8px;
+        margin: 8px;
         border: $border_style_menu;
         box-shadow: $shadow_content;
         &:hover {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,9 +6,7 @@ class ItemsController < ApplicationController
   }, only: [:new, :edit, :update, :delete]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :set_items, only: [:index, :new, :create, :edit]
-  # before_action :set_all_woms, only: [:index, :new, :create, :edit]
   before_action :set_clip_user_and_shop, only: [:index, :new]
-  # before_action :set_clips, only: [:index, :new, :create, :edit]
 
   def index
     @top_brands = @shop.brands.limit(5)
@@ -40,6 +38,11 @@ class ItemsController < ApplicationController
     @item.destroy ? (redirect_to shop_items_path(@shop.id)):(render :index)
   end
 
+  def import
+    Item.import(params[:file], @shop.id)
+    redirect_to shop_items_path(@shop.id)
+  end
+
   private
   def set_shop
     @shop = Shop.find(params[:shop_id])
@@ -50,7 +53,7 @@ class ItemsController < ApplicationController
   end
 
   def set_items
-    @items = @shop.items.paginate(page: params[:page], per_page: 5).order('created_at DESC')
+    @items = @shop.items.paginate(page: params[:page], per_page: 10).order('created_at DESC')
   end
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,4 +3,25 @@ class Item < ApplicationRecord
   has_many_attached :images
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :item_status
+
+  def self.import(file, shop_id)
+    CSV.foreach(file.path, headers: true) do |row|
+      item = find_by(id: row["id"]) || new
+      item.attributes = row.to_hash.slice(*updatable_attributes)
+      item.shop_id = shop_id
+      item.save
+    end
+  end
+
+  def self.updatable_attributes
+    [
+      "id",
+      "name",
+      "item_status_id",
+      "explanation",
+      "price",
+      "size",
+      "size_detail",
+    ]
+  end
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,5 +17,10 @@
         = link_to(shop_map_path(@shop.id), class: 'shop-menu-link') do
           %span.shop-menu-name 地図
     .shop-content
-      %h2 新規商品投稿
-      = render 'items/form'
+      #new_item_form
+        %h2 新規商品投稿
+        = render 'items/form'
+        .item_import_form
+          = form_with url: import_shop_items_path, multipart: true do |f|
+            = f.file_field :file
+            = f.submit 'インポート', class: 'btn btn-primary'

--- a/app/views/shops/index.html.haml
+++ b/app/views/shops/index.html.haml
@@ -2,7 +2,7 @@
 = render "layouts/breadcrumbs"
 = render "shops/searched_heading"
 .shop-paginate
-  = will_paginate @shops, renderer: WillPaginate::ActionView::LinkRenderer
+  = will_paginate @shops, renderer: BootstrapPagination::Rails
 = render 'shop', shops: @shops
 .shop-paginate
-  = will_paginate @shops, renderer: WillPaginate::ActionView::LinkRenderer
+  = will_paginate @shops, renderer: BootstrapPagination::Rails

--- a/app/views/shops/items.html.haml
+++ b/app/views/shops/items.html.haml
@@ -53,6 +53,7 @@
                             = link_to '削除', shop_item_path(@shop, item.id), method: :delete, data: { confirm: '本当に削除して良いですか?',cancel: 'やめる',commit: '削除する',disable_with: "処理中..."}, title: '削除確認'
             - else
               %span.no_register 取扱商品はまだ登録されていません
+          = will_paginate @items, renderer: BootstrapPagination::Rails
         - if user_signed_in? 
           - if @shop.shop_admin == current_user or current_user.admin?
             .item_post

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'csv'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,9 @@ Rails.application.routes.draw do
   end
   resources :shops do
     resources :woms
-    resources :items
+    resources :items do
+      collection { post :import }
+    end
     get 'map', to: 'shops#map'
   end
   resources :areas, only: :index


### PR DESCRIPTION
# What
CSVデータを読み込み、取扱商品を一括で登録できる機能を実装する

# Why
店舗管理者が1点ずつしか商品を登録できないのは、手間である上、商品数を拡大できない原因となる。
そうなると結果的に情報量が少なくなり、サイトとしての信頼性も高まらない。この機能を実装することで、登録商品数が増えてサイトの情報量も高まる。